### PR TITLE
Fix version mismatch between module and 'changes' file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for MojoX-Renderer-Xslate
 
-0.10  Tue May  6 13:00:00 UTC 2014
+0.092 Tue May  6 13:00:00 UTC 2014
     - Tweak to work with FormHelpers plugin
 
 0.09  Thu Jun  6 03:34:47 UTC 2013


### PR DESCRIPTION
The version defined in the `Changes` file for the latest release deviates from the actual version defined in the module. This change updates the `Changes` file to ensure the version numbers match prior to any future release of this module.

See https://github.com/companieshouse/mojox-renderer-xslate/commit/114a358963a3e983498617701f679ceb8ff24fbf for reference.