### PR TITLE
Update deprecated mojolicious methods to support latest release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for MojoX-Renderer-Xslate
 
+{{NEXT}}
+
+0.093 Mon Oct 16 14:50:00 UTC 2017
+    - Update deprecated mojolicious methods to support latest release
+
 0.10  Tue May  6 13:00:00 UTC 2014
     - Tweak to work with FormHelpers plugin
 

--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -27,10 +27,10 @@ sub _init {
 
     my $app = $args{mojo} || $args{app};
     my $cache_dir;
-    my @path = $app->home->rel_dir('templates');
+    my @path = $app->home->rel_file('templates');
 
     if ($app) {
-        $cache_dir = $app->home->rel_dir('tmp/compiled_templates');
+        $cache_dir = $app->home->rel_file('tmp/compiled_templates');
         foreach my $class ( @{$app->renderer->classes} ) {
             push @path, Mojo::Loader->new->data( $class );
         }

--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -8,7 +8,7 @@ use Mojo::Base -base;
 use Mojo::Loader;
 use Text::Xslate ();
 
-our $VERSION = '0.092';
+our $VERSION = '0.093';
 $VERSION = eval $VERSION;
 
 has 'xslate';

--- a/lib/MojoX/Renderer/Xslate.pm
+++ b/lib/MojoX/Renderer/Xslate.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use File::Spec ();
 use Mojo::Base -base;
-use Mojo::Loader;
+use Mojo::Loader qw(data_section);
 use Text::Xslate ();
 
 our $VERSION = '0.093';
@@ -32,7 +32,7 @@ sub _init {
     if ($app) {
         $cache_dir = $app->home->rel_file('tmp/compiled_templates');
         foreach my $class ( @{$app->renderer->classes} ) {
-            push @path, Mojo::Loader->new->data( $class );
+            push @path, data_section( $class );
         }
     }
     else {

--- a/t/lite_app.t
+++ b/t/lite_app.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use Test::Mojo;
 
+use Mojo::Loader qw(data_section);
+
 use Mojolicious::Lite;
 
 # Silence
@@ -15,7 +17,7 @@ my $xslate = MojoX::Renderer::Xslate->build(
     mojo             => app,
     template_options => {
         syntax => 'TTerse',
-        path   => [ Mojo::Loader->new->data(__PACKAGE__) ],
+        path   => [ data_section(__PACKAGE__) ],
     },
 );
 app->renderer->add_handler(tt => $xslate);


### PR DESCRIPTION
The `rel_dir` method has been deprecated in favour of `rel_file` in recent versions of `Mojolicious`. See https://metacpan.org/changes/distribution/Mojolicious#L384. 

This update is required to allow the use of a more recent version of `Mojolicious` for the `ch.gov.uk` and `api.ch.gov.uk` services.